### PR TITLE
Fix #8 Use atom.workspace.open to prevent yanking focus

### DIFF
--- a/lib/tab-manager.js
+++ b/lib/tab-manager.js
@@ -144,7 +144,7 @@ class TabManager {
     }
 
     if (tabsToOpen.length > 0) {
-      atom.open({ pathsToOpen: tabsToOpen })
+      tabsToOpen.map(filename => atom.workspace.open(filename))
     }
 
     this.updating = false


### PR DESCRIPTION
This seems to be working for me on Linux. It seems like this should probably work fine on OS X too.